### PR TITLE
Update links to the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # jupyterlab-unfold
 
-![Github Actions Status](https://github.com/martinRenou/jupyterlab-unfold/actions/workflows/build.yml/badge.svg?branch=master)[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/martinRenou/jupyterlab-unfold/HEAD?urlpath=lab)
+![Github Actions Status](https://github.com/jupyterlab-contrib/jupyterlab-unfold/actions/workflows/build.yml/badge.svg?branch=master)[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jupyterlab-contrib/jupyterlab-unfold/HEAD?urlpath=lab)
 
 An IDE-like file browser
 

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
     "jupyterlab",
     "jupyterlab-extension"
   ],
-  "homepage": "https://github.com/martinRenou/jupyterlab-unfold",
+  "homepage": "https://github.com/jupyterlab-contrib/jupyterlab-unfold",
   "bugs": {
-    "url": "https://github.com/martinRenou/jupyterlab-unfold/issues"
+    "url": "https://github.com/jupyterlab-contrib/jupyterlab-unfold/issues"
   },
   "license": "BSD-3-Clause",
   "author": {
@@ -31,7 +31,7 @@
   "style": "style/index.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/martinRenou/jupyterlab-unfold.git"
+    "url": "https://github.com/jupyterlab-contrib/jupyterlab-unfold.git"
   },
   "scripts": {
     "build": "jlpm run build:lib && jlpm run build:labextension:dev",

--- a/ui-tests/package.json
+++ b/ui-tests/package.json
@@ -2,7 +2,7 @@
   "name": "jupyterlab-unfold-tests",
   "version": "0.1.0",
   "description": "UI tests",
-  "repository": "https://github.com/martinRenou/jupyterlab-unfold",
+  "repository": "https://github.com/jupyterlab-contrib/jupyterlab-unfold",
   "author": "Martin Renou",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
As a follow-up to the move to the `jupyterlab-contrib` org.