### PR TITLE
Export everything from the unfold file

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -111,4 +111,5 @@ const extension: JupyterFrontEndPlugin<IFileBrowserFactory> = {
   }
 };
 
+export * from './unfold';
 export default extension;


### PR DESCRIPTION
So that we can reuse the FileTreeBrowser in lab remixes