### PR TITLE
Open shared link

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -69,6 +69,17 @@ const fileBrowserFactory: JupyterFrontEndPlugin<IFileBrowserFactory> = {
         widget.listing.singleClickToUnfold = setting.get('singleClickToUnfold')
           .composite as boolean;
       });
+   
+      // check the url in iframe and open
+      app.restored.then(() => {
+        console.log(window.location.pathname);
+        const windowPathname = window.location.pathname;
+        let treeIndex = windowPathname.indexOf('/tree/');
+        let path = windowPathname.substring(treeIndex + '/tree/'.length);
+        path = decodeURIComponent(path);
+        console.log(`path after decoding is: ${path}`);
+        docManager.open(path);
+      });
 
       // Track the newly created file browser.
       void tracker.add(widget);

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,12 +72,10 @@ const fileBrowserFactory: JupyterFrontEndPlugin<IFileBrowserFactory> = {
    
       // check the url in iframe and open
       app.restored.then(() => {
-        console.log(window.location.pathname);
         const windowPathname = window.location.pathname;
         let treeIndex = windowPathname.indexOf('/tree/');
         let path = windowPathname.substring(treeIndex + '/tree/'.length);
         path = decodeURIComponent(path);
-        console.log(`path after decoding is: ${path}`);
         docManager.open(path);
       });
 


### PR DESCRIPTION
The fix is to read the url from the iframe and use docmanager to open it. The assumption is that the actual path will start after "/tree/". Since it will pick the first occurence of /tree/, there won't a conflict if a folder is named `tree` in the path.

Tested on local
![Open file gif](https://github.com/jupyterlab-contrib/jupyterlab-unfold/assets/142968737/3116c544-ae71-4afb-aa26-6e5deafe7c1a)

