### PR TITLE
emit FileBrowserModel.pathChanged signal

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,8 +66,7 @@
         "@jupyterlab/docmanager": "^4.0.5",
         "@jupyterlab/filebrowser": "^4.0.5",
         "@jupyterlab/services": "^7.0.5",
-        "@lumino/algorithm": "^2.0.0",
-        "@lumino/signaling": "^2.1.2"
+        "@lumino/algorithm": "^2.0.0"
     },
     "devDependencies": {
         "@jupyterlab/builder": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
         "@jupyterlab/filebrowser": "^4.0.5",
         "@jupyterlab/services": "^7.0.5",
         "@lumino/algorithm": "^2.0.0",
-        "@lumino/signaling": "^2.0.0"
+        "@lumino/signaling": "^2.1.2"
     },
     "devDependencies": {
         "@jupyterlab/builder": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
         "@jupyterlab/docmanager": "^4.0.5",
         "@jupyterlab/filebrowser": "^4.0.5",
         "@jupyterlab/services": "^7.0.5",
-        "@lumino/algorithm": "^2.0.0"
+        "@lumino/algorithm": "^2.0.0",
+        "@lumino/signaling": "^2.0.0"
     },
     "devDependencies": {
         "@jupyterlab/builder": "^4.0.0",

--- a/src/unfold.ts
+++ b/src/unfold.ts
@@ -430,14 +430,13 @@ export class FilterFileTreeBrowserModel extends FilterFileBrowserModel {
   set path(value: string) {
     const pathChanged = this.pathChanged as Signal<this, IChangedArgs<string>>;
     const oldValue = this._path;
-    const newValue = value;
 
     this._path = value;
 
     pathChanged.emit({
       name: 'path',
       oldValue,
-      newValue
+      newValue: value
     });
   }
 

--- a/src/unfold.ts
+++ b/src/unfold.ts
@@ -8,6 +8,8 @@ import { ElementExt } from '@lumino/domutils';
 
 import { PromiseDelegate, ReadonlyJSONObject } from '@lumino/coreutils';
 
+import { Signal } from '@lumino/signaling';
+
 import { DOMUtils, showErrorMessage } from '@jupyterlab/apputils';
 
 import { JupyterFrontEnd } from '@jupyterlab/application';
@@ -18,7 +20,7 @@ import { DocumentRegistry } from '@jupyterlab/docregistry';
 
 import { renameFile } from '@jupyterlab/docmanager';
 
-import { PathExt } from '@jupyterlab/coreutils';
+import { PathExt, IChangedArgs } from '@jupyterlab/coreutils';
 
 import {
   DirListing,
@@ -426,7 +428,17 @@ export class FilterFileTreeBrowserModel extends FilterFileBrowserModel {
   }
 
   set path(value: string) {
+    const pathChanged = this.pathChanged as Signal<this, IChangedArgs<string>>;
+    const oldValue = this._path;
+    const newValue = value;
+
     this._path = value;
+
+    pathChanged.emit({
+      name: 'path',
+      oldValue,
+      newValue
+    });
   }
 
   /**


### PR DESCRIPTION
This is for compatibility with other extensions (like jupyterlab-git) that register listeners on FileBrowserModel.pathChanged.

Tested locally with `jupyterlab-git`. Before change, the plugin is unable to detect that you are in a git repo when clicking on directory containing a git repo. After change, plugin is able to detect presence of git repo based on last clicked path.